### PR TITLE
Fix: typo praseInput -> parseInput in Spule.html

### DIFF
--- a/Elektrotechnik/Spule.html
+++ b/Elektrotechnik/Spule.html
@@ -575,7 +575,7 @@
                             <span>${U}V</span><br>
                             <span class="fraction-denominator">${B}T &lowast; ${l}m</span>
                         </div>
-                    = ${formatWithPrefix(parseInput(U) / (praseInput(B) * parseInput(l)), "m/s")}<br>`;
+                    = ${formatWithPrefix(parseInput(U) / (parseInput(B) * parseInput(l)), "m/s")}<br>`;
                 }
 
                 /*if(!A)       // Flaeche A todo
@@ -689,7 +689,7 @@
                             <span>${L}H</span><br>
                             <span class="fraction-denominator">(${N})<sup>2</sup></span>
                         </div>
-                    = ${formatWithPrefix(parseInput(L) / Math.pow(praseInput(N), 2), "Vs/A")}<br>`;
+                    = ${formatWithPrefix(parseInput(L) / Math.pow(parseInput(N), 2), "Vs/A")}<br>`;
                 }
 
                 if(!l)  // Leiterlaenge l
@@ -723,7 +723,7 @@
                                 <span>${U}V</span><br>
                                 <span class="fraction-denominator">${B}T &lowast; ${v}m/s</span>
                             </div>
-                        = ${formatWithPrefix(parseInput(U) / (praseInput(B) * parseInput(v)), "")}<br>`;
+                        = ${formatWithPrefix(parseInput(U) / (parseInput(B) * parseInput(v)), "")}<br>`;
                     }
                 }
 


### PR DESCRIPTION
This pull request fixes a typo in `Elektrotechnik/Spule.html` where `praseInput` was used instead of `parseInput` in several places. This typo caused a ReferenceError and broke inductor calculations on the Spule page.

**How the bug was found:**
- Discovered during automated testing (Cypress) in my fork.
- The error prevented calculations from working and caused some tests to fail.

**What this PR does:**
- Replaces all instances of `praseInput` with the correct `parseInput` function.
- Restores correct calculation functionality for Spule.

There is currently no open issue for this bug in upstream, but this PR resolves the error and restores the intended behavior.

Thank you for maintaining this project!