### PR TITLE
Fix Rechteck Effektivwert calculation in Wechselstrom.html

### DIFF
--- a/Elektrotechnik/Wechselstrom.html
+++ b/Elektrotechnik/Wechselstrom.html
@@ -952,21 +952,70 @@
             
         }*/
 
-        function calculate_Rechteck()
-        {
+        function calculate_Rechteck() {
             let result_Rechteck = ``;
 
-            const ut = document.getElementById("ut-Rechteck").value;
+            const up = document.getElementById("up-Rechteck").value;
+            const upp = document.getElementById("upp-Rechteck").value;
+            const Ueff = document.getElementById("Ueff-Rechteck").value;
 
-            if(!ut)     // Momentanwert
-            {
-                if(up && f && t)
-                {
+            // Calculate missing up (peak)
+            if (!up) {
+                if (upp) {
                     result_Rechteck += `
-                    Momentanwert u(t) = &ucirc; &lowast; sin(2&pi; &lowast; f &lowast; t)
-                =
-                    ${up}V &lowast; sin(2&pi; &lowast; ${f}Hz &lowast; ${t}s)
-                = ${formatWithPrefix(parseInput(up)*Math.sin(2 * Math.PI * parseInput(f) * parseInput(t)), "V")}<br>`;
+                        Peakspannung &ucirc; =
+                        <div class="fraction">
+                            <span>u<sub>pp</sub></span><br>
+                            <span class="fraction-denominator">2</span>
+                        </div>
+                        = <div class="fraction">
+                            <span>${upp}V</span><br>
+                            <span class="fraction-denominator">2</span>
+                        </div>
+                        = ${formatWithPrefix(parseInput(upp)/2, "V")}<br>`;
+                }
+                if (Ueff) {
+                    result_Rechteck += `
+                        Peakspannung &ucirc; = U<sub>eff</sub>
+                        = ${Ueff}V<br>`;
+                }
+            }
+
+            // Calculate missing upp (peak-peak)
+            if (!upp) {
+                if (up) {
+                    result_Rechteck += `
+                        Peak-Peakspannung u<sub>pp</sub> = 2 &lowast; &ucirc;
+                        = 2 &lowast; ${up}V
+                        = ${formatWithPrefix(2 * parseInput(up), "V")}<br>`;
+                }
+                if (Ueff) {
+                    result_Rechteck += `
+                        Peak-Peakspannung u<sub>pp</sub> = 2 &lowast; U<sub>eff</sub>
+                        = 2 &lowast; ${Ueff}V
+                        = ${formatWithPrefix(2 * parseInput(Ueff), "V")}<br>`;
+                }
+            }
+
+            // Calculate missing Ueff (RMS)
+            if (!Ueff) {
+                if (up) {
+                    result_Rechteck += `
+                        Effektivspannung U<sub>eff</sub> = &ucirc;
+                        = ${up}V<br>`;
+                }
+                if (upp) {
+                    result_Rechteck += `
+                        Effektivspannung U<sub>eff</sub> =
+                        <div class="fraction">
+                            <span>u<sub>pp</sub></span><br>
+                            <span class="fraction-denominator">2</span>
+                        </div>
+                        = <div class="fraction">
+                            <span>${upp}V</span><br>
+                            <span class="fraction-denominator">2</span>
+                        </div>
+                        = ${formatWithPrefix(parseInput(upp)/2, "V")}<br>`;
                 }
             }
 


### PR DESCRIPTION
Hi,

This PR updates the calculation logic for the Rechteck (square wave) Effektivwert in `Wechselstrom.html`.

I’ve implemented the standard relationships for square waves:
- U_eff = û
- û = u_pp / 2
- u_pp = 2 * û

I tested the changes locally and the results seem correct.
However, I want to mention that I’m not 100% confident about the formulas themselves (not the code)—so if there’s a more accurate or standard approach, please let me know! 😅

This should fix the "Rechteck: funktioniert gar nicht" part of [issue #3](https://github.com/jaduruch/elecalculate/issues/3).

By the way, I just wanted to say I’m really impressed by the size and scope of this project—15,000 lines of HTML is a huge solo achievement! I ran:

```
find . -name "*.html" -type f -exec cat {} + | wc -l
```

and got 14,401 lines. That’s a massive amount of work -> thanks for making this resource available and for all your effort maintaining it.

If you prefer, I can also write the description or comments in German.

LG,  
Paul