### PR TITLE
Fix JS exception when no slides exist & typo in spule.html (parseInput)

### DIFF
--- a/Elektrotechnik/Spule.html
+++ b/Elektrotechnik/Spule.html
@@ -479,7 +479,7 @@
                         <span>${U}V</span><br>
                         <span class="fraction-denominator">${B}T &lowast; ${l}m</span>
                     </div>
-                = ${formatWithPrefix(parseInput(U) / (praseInput(B) * parseInput(l)), "m/s")}<br>`;
+                = ${formatWithPrefix(parseInput(U) / (parseInput(B) * parseInput(l)), "m/s")}<br>`;
             }
 
             /*if(!A)       // Flaeche A todo
@@ -593,7 +593,7 @@
                         <span>${L}H</span><br>
                         <span class="fraction-denominator">(${N})<sup>2</sup></span>
                     </div>
-                = ${formatWithPrefix(parseInput(L) / Math.pow(praseInput(N), 2), "Vs/A")}<br>`;
+                = ${formatWithPrefix(parseInput(L) / Math.pow(parseInput(N), 2), "Vs/A")}<br>`;
             }
 
             if(!l)  // Leiterlaenge l
@@ -627,7 +627,7 @@
                             <span>${U}V</span><br>
                             <span class="fraction-denominator">${B}T &lowast; ${v}m/s</span>
                         </div>
-                    = ${formatWithPrefix(parseInput(U) / (praseInput(B) * parseInput(v)), "")}<br>`;
+                    = ${formatWithPrefix(parseInput(U) / (parseInput(B) * parseInput(v)), "")}<br>`;
                 }
             }
 

--- a/scripts.js
+++ b/scripts.js
@@ -7,6 +7,9 @@ function changeSlide(n) {
 
 function showSlides(n) {
     let slides = document.getElementsByClassName("slide");
+    // Guard clause: If there are no elements with class "slide", exit early.
+    if (slides.length === 0) return;
+
     if (n > slides.length) { slideIndex = 1 }
     if (n < 1) { slideIndex = slides.length }
     for (let i = 0; i < slides.length; i++) {


### PR DESCRIPTION
Hi Jana,

I found a couple of little things while testing and thought I’d send them your way:

- **No more console error:**  
  I added a quick check in `showSlides()` so it won’t throw an error if there aren’t any slides on the page. Just keeps things tidy in the browser console.  
![Screenshot 2025-05-23 000956](https://github.com/user-attachments/assets/114939c4-11fc-4755-8415-6d578fa7cbf6)


- **praseInput returns!**  
  I spotted the `praseInput` typo again in `Spule.html`—it’s a persistent one! 😄 Fixed it so the calculations work as expected.

Both of these popped up during some automated and manual testing. 

Thanks again for all your work on this project. It’s really cool to see how much it’s growing!

LG,  
Paul